### PR TITLE
Fix error de compilación por tocstyle

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -84,9 +84,13 @@ Corresponde a la traducción al idioma inglés de Palabras Clave anteriores.
 \usepackage[colorlinks=true, allcolors=blue]{hyperref}
 
 % Formato de las tablas de contenido
-% \usepackage[tocflat]{tocstyle}
 \usepackage{tocbasic}
+
+%% Originalmente se usaba tocstyle en vez de tocbasic.
+%% Si se quiere usar, descomentar:
+% \usepackage[tocflat]{tocstyle}
 % \usetocstyle{allwithdot}
+%% tocstyle.sty se obtener de https://github.com/firemodels/fds/blob/master/Manuals/LaTeX_Style_Files/tocstyle.sty
 
 % Para obtener el número de la última página
 \usepackage{lastpage}

--- a/main.tex
+++ b/main.tex
@@ -85,8 +85,8 @@ Corresponde a la traducción al idioma inglés de Palabras Clave anteriores.
 
 % Formato de las tablas de contenido
 % \usepackage[tocflat]{tocstyle}
-\usepackage{tocstyle}
-\usetocstyle{allwithdot}
+\usepackage{tocbasic}
+% \usetocstyle{allwithdot}
 
 % Para obtener el número de la última página
 \usepackage{lastpage}


### PR DESCRIPTION
Cambiar tocstyle por tocbasic, ya que la linea \usetocstyle{allwithdot} genera un error de compilación, incluso usando XeLaTeX o LuaLaTeX.