### PR TITLE
Añadir parámetro de centrado a paquete caption

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -41,6 +41,9 @@ Corresponde a la traducción al idioma inglés de Palabras Clave anteriores.
 % Directorio de las imágenes
 \graphicspath{ {figures/} }
 
+% Centrar captions de imagenes, en caso de ocupar multiples lineas
+\usepackage[justification=centering]{caption}
+
 % Idioma y fuentes
 \usepackage[spanish,es-tabla]{babel}
 \usepackage[T1]{fontenc}


### PR DESCRIPTION
Se añade el parámetro [justification=centering] para que los subtítulos (captions) de las imágenes se centren, incluso si el texto es demasiado largo y ocupa múltiples líneas.